### PR TITLE
Symmetrization of Cov

### DIFF
--- a/julia/gspice.jl
+++ b/julia/gspice.jl
@@ -526,7 +526,7 @@ function gspice_gp_interp(Dvec, covmat; irange=nothing, nguard=20, bruteforce=fa
     t0 = now()
 
     # -------- pre-compute inverse covariance
-    covinv = inv(cholesky(covmat))
+    covinv = inv(cholesky(Symmetric(covmat)))
 
     # -------- loop over spectral pixels
     for i=i1:i2
@@ -590,7 +590,6 @@ function gspice_chimask(flux, ivar, mask, nsigma)
 
     # -------- obtain the empirical covariance for this Dvec
     covmat, __ = gspice_covar(Dvec)
-    return covmat
 
     # -------- compute GSPICE predicted mean and variance
     pred, predvar = gspice_gp_interp(Dvec, covmat, nguard=20)

--- a/julia/gspice.jl
+++ b/julia/gspice.jl
@@ -230,6 +230,7 @@ function gspice_covar(spec::Array{Float64,2}; checkmean=false)
     # -------- compute covariance
     cov = (spec0'*spec0)./(Nspec-1)
     if !issymmetric(cov)
+        println("Warning: Had to symmetrize the matrix!")
         cov .+= cov'
         cov ./=2
     end
@@ -589,6 +590,7 @@ function gspice_chimask(flux, ivar, mask, nsigma)
 
     # -------- obtain the empirical covariance for this Dvec
     covmat, __ = gspice_covar(Dvec)
+    return covmat
 
     # -------- compute GSPICE predicted mean and variance
     pred, predvar = gspice_gp_interp(Dvec, covmat, nguard=20)

--- a/julia/gspice.jl
+++ b/julia/gspice.jl
@@ -225,12 +225,14 @@ function gspice_covar(spec::Array{Float64,2}; checkmean=false)
     if checkmean
         mnd = sum(spec0, dims=1) ./ Nspec
         println("Min, max, mean ", extrema(mnd), std(mnd))
+        flush(stdout)
     end
 
     # -------- compute covariance
     cov = (spec0'*spec0)./(Nspec-1)
     if !issymmetric(cov)
         println("Warning: Had to symmetrize the matrix!")
+        flush(stdout)
         cov .+= cov'
         cov ./=2
     end
@@ -269,7 +271,7 @@ function gspice_submatrix_inv(M, Minv, imask; bruteforce=false)
     # -------- brute force option, for testing
     if bruteforce
         k    = findall(imask)
-        Ainv = inv(cholesky(M[k, k]))
+        Ainv = inv(cholesky(Symmetric(M[k, k])))
         return Ainv
     end
 
@@ -280,6 +282,7 @@ function gspice_submatrix_inv(M, Minv, imask; bruteforce=false)
     # -------- if there is nothing to do, return early
     if nr==0
       println("imask does not remove any rows/columns...")
+      flush(stdout)
       return Minv
     end
 
@@ -346,7 +349,7 @@ function gspice_submatrix_inv_mult(M, Minv, imask, Y, MinvY; irange=nothing, pad
     # -------- brute force option (Slow - use only for testing)
     if bruteforce
         k     = findall(imask)
-        Ainv  = inv(cholesky(M[k, k]))
+        Ainv  = inv(cholesky(Symmetric(M[k, k])))
         Ainvy = Ainv * Y[k, :]
         return Ainvy
     end
@@ -435,7 +438,7 @@ function gspice_gaussian_estimate(icond, ipred, covmat, Dvec, covinv; bruteforce
         cov_kstarkstar = covmat[kstar, kstar]
 
         # -------- Choleksy inversion
-        icov_kk = inv(cholesky(cov_kk))
+        icov_kk = inv(cholesky(Symmetric(cov_kk)))
 
         # -------- compute the prediction covariance (See RW, Chap. 2)
         predcovar = cov_kstarkstar - (cov_kkstar*(icov_kk*cov_kstark))
@@ -643,10 +646,12 @@ function gspice_covar_iter_mask(flux, ivar, mask; nsigma=[20, 8, 6], maxbadpix=6
     thismask = false
     for iter = 1:length(nsigma)
         println("=========================  Pass ", iter, ",   cut at Nsigma = ", nsigma[iter])
+        flush(stdout)
         thismask = chimask .| (mask[wmask,:] .!= 0)
         chimask = gspice_chimask(flux[wmask,:], ivar[wmask,:], thismask, nsigma[iter])
         println("mean chimask: ", mean(chimask))
         println("Time: ", (now()-t0).value/1000, " sec")
+        flush(stdout)
     end
 
   finalmask = trues(nspec, npix)    # start from original mask, overwrite mask for good spectra

--- a/julia/gspice.jl
+++ b/julia/gspice.jl
@@ -229,7 +229,10 @@ function gspice_covar(spec::Array{Float64,2}; checkmean=false)
 
     # -------- compute covariance
     cov = (spec0'*spec0)./(Nspec-1)
-
+    if !issymmetric(cov)
+        cov .+= cov'
+        cov ./=2
+    end
     return cov, refmean
 end
 

--- a/julia/gspice.jl
+++ b/julia/gspice.jl
@@ -551,7 +551,10 @@ function gspice_gp_interp(Dvec, covmat; irange=nothing, nguard=20, bruteforce=fa
         end
         predvar[:, kstar.-(i1-1)] .= diag(predcovar)
 
-        if mod(i,100)==0 println(i, "  ",(now()-t0).value/1000.0, " sec") end
+        if mod(i,100)==0
+            println(i, "  ",(now()-t0).value/1000.0, " sec")
+            flush(stdout)
+        end
     end
 
     if ~bruteforce pred = Dvec*predoverD end


### PR DESCRIPTION
Added explicit symmetrization of gspice_covar (likely not strictly necessary). Symmetric wrappers added internal to all cholesky calls. Julia LA is moving towards REQUIRING Symmetric or Hermitian wrappers and accepting no other types in cholesky in order to specialize and prevent issues. Symmetric wrapper would simply take UT of matrix without explicit symmetrization added in gspice_covar (probably fine). Some computational savings are possibly by judicious placement of Symmetric(), but for now I just cautiously put them inside all cholesky calls. To aid verbosity, I also now flush stdout. This appears to have solved my issue with APOGEE spectra. Unit tests don't appear set up, but let me know if you want me to run/if I fail any of them. It might be a good idea to split the julia fork off into GSPICE.jl so its dependencies can be managed properly.